### PR TITLE
CHANGE/FEATURE: as.datalist splits automatically by condition 

### DIFF
--- a/R/dataClass.R
+++ b/R/dataClass.R
@@ -9,18 +9,24 @@
 #' @return Object of class \link{datalist}
 #' @export
 #' @example inst/examples/datalist.R
+#' @example inst/examples/datalistdataframe.R
 #' @rdname datalist
 as.datalist <- function(x, ...) {
   UseMethod("as.datalist", x)
 }
 
 #' @export
-#' @param split.by vector of columns names which yield a unique identifier (conditions). If NULL, all
-#' columns except for the expected standard columns "name", "time", "value", "sigma" and "lloq" will be
+#' @param split.by vector of columns names which yield a unique identifier (conditions). 
+#' If NULL, two cases are possible: 
+#'   1. if available, split by the column called "condition", 
+#'   2. If the column "condition" is not available all columns except for the expected standard columns "name", "time", "value", "sigma" and "lloq" will be
 #' selected.
-#' @param keep.covariates vector of additional column names which should be kept in the condition.grid.
+#' @param keep.covariates Three options: 
+#'    1. FALSE = don't keep any
+#'    2. TRUE = keep all covariates
+#'    3. vector of additional column names which should be kept in the condition.grid.
 #' @rdname datalist
-as.datalist.data.frame <- function(x, split.by = NULL, keep.covariates = NULL, ...) {
+as.datalist.data.frame <- function(x, split.by = NULL, keep.covariates = TRUE, ...) {
 
   # Sanitize data and get names
   x <- sanitizeData(x)
@@ -28,17 +34,31 @@ as.datalist.data.frame <- function(x, split.by = NULL, keep.covariates = NULL, .
   standard.names <- x[["columns"]]
   all.names <- colnames(dataframe)
   
-  # Get splitting information
-  if (is.null(split.by)) split.by <- setdiff(all.names, standard.names)
+  # Get splitting information: Split per default by "condition" if available
+  if (is.null(split.by)){
+    if ("condition" %in% all.names){
+      split.by <- "condition"
+    } else {
+      split.by <- setdiff(all.names, standard.names)
+    }}
   conditions <- lapply(split.by, function(n) dataframe[, n])
   splits <- do.call(paste, c(conditions, list(sep = "_")))
 
 
-  # condition grid
+  # condition grid: implement support for is.logical(keep.covariates)
+  if (is.logical(keep.covariates)){
+    if (keep.covariates) {
+      keep.covariates <- setdiff(all.names, standard.names)
+    } else {
+      keep.covariates <- character()
+    }
+  }
+  
   conditionframe <- dataframe[!duplicated(splits), union(split.by, keep.covariates), drop = FALSE]
   rownames(conditionframe) <- splits[!duplicated(splits)]
-
-
+  if (!"condition" %in% all.names)
+    conditionframe <- cbind(conditionframe, condition = rownames(conditionframe), stringsAsFactors = FALSE)
+  
   # data list output
   dataframe <- cbind(data.frame(condition = splits), dataframe[, standard.names])
   out <- lapply(unique(splits), function(s) dataframe[dataframe[, 1] == s, -1])
@@ -48,7 +68,6 @@ as.datalist.data.frame <- function(x, split.by = NULL, keep.covariates = NULL, .
   out <- as.datalist(out)
   attr(out, "condition.grid") <- conditionframe
   return(out)
-
 }
 
 #' @export

--- a/inst/examples/datalistdataframe.R
+++ b/inst/examples/datalistdataframe.R
@@ -1,0 +1,28 @@
+   
+   
+   Eample: Interconversion between datalist and data.frame
+    
+   
+   library(dMod)
+  
+  # * Setting 1: no condition column available but covariates
+  df1 <- expand.grid(name = letters[1:2], time = 1:2, value = 1, sigma = 1, lloq = 0, cov1 = LETTERS[3:4], cov2 = LETTERS[5:6], cov3 = 1:2, stringsAsFactors = FALSE)
+  dl1 <- as.datalist(df1)
+  
+  # * Setting 2: convert back to data.frame -> now has condition column available
+  df2.1 <- as.data.frame(dl1)
+  dl2.1 <- as.datalist(df2.1)
+  identical(df2.1, df1)
+  #   * From the point on when there is a condition-column, we have identical(x, as.datalist(as.data.frame(x)))
+  df2.2 <- as.data.frame(dl2.1)
+  dl2.2 <- as.datalist(df2.2)
+  identical(df2.1, df2.2)
+  
+  # * Setting 3: additional options with keep.covariates and split.by
+  df3.1 <- as.datalist(df1, split.by = "cov1", keep.covariates = FALSE)
+  df3.2 <- as.datalist(df1, split.by = "cov1", keep.covariates = "cov2")
+  df3.3 <- as.datalist(df1, split.by = c("cov1", "cov2"), keep.covariates = TRUE)
+  
+  covariates(df3.1)
+  covariates(df3.2)
+  covariates(df3.3)

--- a/inst/tests/test-datalistdataframe.R
+++ b/inst/tests/test-datalistdataframe.R
@@ -1,0 +1,39 @@
+context("', context, '")
+test_that("', description ,'", {
+  
+  #-!Start example code
+  #-! 
+  #-! 
+  #-! Eample: Interconversion between datalist and data.frame
+  #-!  
+  #-! 
+  #-! library(dMod)
+  
+  # * Setting 1: no condition column available but covariates
+  df1 <- expand.grid(name = letters[1:2], time = 1:2, value = 1, sigma = 1, lloq = 0, cov1 = LETTERS[3:4], cov2 = LETTERS[5:6], cov3 = 1:2, stringsAsFactors = FALSE)
+  dl1 <- as.datalist(df1)
+  
+  # * Setting 2: convert back to data.frame -> now has condition column available
+  df2.1 <- as.data.frame(dl1)
+  dl2.1 <- as.datalist(df2.1)
+  identical(df2.1, df1)
+  #   * From the point on when there is a condition-column, we have identical(x, as.datalist(as.data.frame(x)))
+  df2.2 <- as.data.frame(dl2.1)
+  dl2.2 <- as.datalist(df2.2)
+  identical(df2.1, df2.2)
+  
+  # * Setting 3: additional options with keep.covariates and split.by
+  df3.1 <- as.datalist(df1, split.by = "cov1", keep.covariates = FALSE)
+  df3.2 <- as.datalist(df1, split.by = "cov1", keep.covariates = "cov2")
+  df3.3 <- as.datalist(df1, split.by = c("cov1", "cov2"), keep.covariates = TRUE)
+  
+  covariates(df3.1)
+  covariates(df3.2)
+  covariates(df3.3)
+  #-!End example code
+  
+  id1 <- identical(dl2.2, dl2.1)
+  # Define your expectations here
+  expect_true(id1)
+  
+})

--- a/man/datalist.Rd
+++ b/man/datalist.Rd
@@ -15,7 +15,7 @@ datalist(...)
 as.datalist(x, ...)
 
 \method{as.datalist}{data.frame}(x, split.by = NULL,
-  keep.covariates = NULL, ...)
+  keep.covariates = TRUE, ...)
 
 \method{as.datalist}{list}(x, names = NULL, ...,
   condition.grid = attr(x, "condition.grid"))
@@ -34,11 +34,16 @@ provide "name", "time" and "value" as columns. Columns "sigma" and "lloq" can be
 If "sigma" and "lloq" are missing, they
 are imputed with \code{NA} and \code{-Inf}, respectively.}
 
-\item{split.by}{vector of columns names which yield a unique identifier (conditions). If NULL, all
-columns except for the expected standard columns "name", "time", "value", "sigma" and "lloq" will be
+\item{split.by}{vector of columns names which yield a unique identifier (conditions). 
+If NULL, two cases are possible: 
+  1. if available, split by the column called "condition", 
+  2. If the column "condition" is not available all columns except for the expected standard columns "name", "time", "value", "sigma" and "lloq" will be
 selected.}
 
-\item{keep.covariates}{vector of additional column names which should be kept in the condition.grid.}
+\item{keep.covariates}{Three options: 
+1. FALSE = don't keep any
+2. TRUE = keep all covariates
+3. vector of additional column names which should be kept in the condition.grid.}
 
 \item{names}{optional names vector, otherwise names are taken from \code{mylist}}
 
@@ -101,4 +106,32 @@ plot(data)
 
 condition.grid <- attr(data, "condition.grid")
 print(condition.grid)
+   
+   
+   Eample: Interconversion between datalist and data.frame
+    
+   
+   library(dMod)
+  
+  # * Setting 1: no condition column available but covariates
+  df1 <- expand.grid(name = letters[1:2], time = 1:2, value = 1, sigma = 1, lloq = 0, cov1 = LETTERS[3:4], cov2 = LETTERS[5:6], cov3 = 1:2, stringsAsFactors = FALSE)
+  dl1 <- as.datalist(df1)
+  
+  # * Setting 2: convert back to data.frame -> now has condition column available
+  df2.1 <- as.data.frame(dl1)
+  dl2.1 <- as.datalist(df2.1)
+  identical(df2.1, df1)
+  #   * From the point on when there is a condition-column, we have identical(x, as.datalist(as.data.frame(x)))
+  df2.2 <- as.data.frame(dl2.1)
+  dl2.2 <- as.datalist(df2.2)
+  identical(df2.1, df2.2)
+  
+  # * Setting 3: additional options with keep.covariates and split.by
+  df3.1 <- as.datalist(df1, split.by = "cov1", keep.covariates = FALSE)
+  df3.2 <- as.datalist(df1, split.by = "cov1", keep.covariates = "cov2")
+  df3.3 <- as.datalist(df1, split.by = c("cov1", "cov2"), keep.covariates = TRUE)
+  
+  covariates(df3.1)
+  covariates(df3.2)
+  covariates(df3.3)
 }


### PR DESCRIPTION
New standard options which make as.datalist(as.data.frame(x)) an identity as soon as a "condition"-column is available in the data.frame/condition.grid

I wrote a little additional unittest/example in examples/datalistdataframe.R to explain the functionality. 

I think, as it is implemented now, it doesn't break a lot of code, since the beginning of the dataframe-datalist-cycle is the same. However, I still am in favour of requiring a condition-column in the data.frame from the beginning, as dMod is very much based on this concept and this makes it very confusing from the outside to realize the data standard of dMod which in my opinion includes the condition-column...